### PR TITLE
Fix: Timer not stopping below -1000L.

### DIFF
--- a/timer/src/main/java/com/dariobrux/kotimer/Timer.kt
+++ b/timer/src/main/java/com/dariobrux/kotimer/Timer.kt
@@ -71,7 +71,7 @@ class Timer {
             currentDuration -= 1_000
 
             // When I arrive to -1 it means that all the milliseconds at 0 seconds are passed.
-            if (currentDuration == -1_000L) {
+            if (currentDuration <= -1_000L) {
                 end()
                 return@fixedRateTimer
             }


### PR DESCRIPTION
Problem: Durations like 3014L, 4421L, etc. never trigger end(). Only durations like 3000L, 4000L, etc. can
Solution: Replace `currentDuration == -1000L` with `currentDuration <= -1000L`, so the end() gets triggered if `currentDuration` goes below -1000L.